### PR TITLE
Fixes race condition for multinode during folder creation

### DIFF
--- a/src/tasks.py
+++ b/src/tasks.py
@@ -42,8 +42,7 @@ def train(config: Dict[str, Any],
     """
     seed_everything(seed, workers=True)
     
-    if not os.path.exists(out_dir):
-        os.makedirs(out_dir)
+    os.makedirs(out_dir, exist_ok=True)
     
     logger, data, trainer_kwargs, model, callbacks = config["log"], \
                                               config["data"], \
@@ -84,8 +83,7 @@ def finetune(config: Dict[str, Any],
     """
     seed_everything(seed, workers=True)
     
-    if not os.path.exists(out_dir):
-        os.makedirs(out_dir)
+    os.makedirs(out_dir, exist_ok=True)
     
     logger, data, trainer_kwargs, model, callbacks = config["log"], \
                                               config["data"], \
@@ -142,8 +140,7 @@ def evaluate(
     Note: Evaluation must be run in a single run as resuming the trainer state is not supported for prediction.
     """
     seed_everything(seed, workers=True)
-    if not os.path.exists(out_dir):
-        os.makedirs(out_dir)
+    os.makedirs(out_dir, exist_ok=True)
 
     logger, data, trainer_kwargs, model, callbacks = config["log"], \
                                           config["data"], \


### PR DESCRIPTION
Inside `tasks.py` the following line exists for creating folders.
```
if not os.path.exists(out_dir):
        os.makedirs(out_dir)
```
However, if you have a multi-node system running, this may happen.
```
Process 0 checks os.path.exists(out_dir) → returns False
Process 1 checks os.path.exists(out_dir) → returns False
Process 0 calls os.makedirs(out_dir) → succeeds
Process 1 calls os.makedirs(out_dir) → fails with FileExistsError
```
Thus, the solution here is to use `os.makedirs(out_dir, exist_ok=True)`